### PR TITLE
feat: GitHub Pagesデプロイ時にビルド&正しい階層に出力する

### DIFF
--- a/takeyo/package.json
+++ b/takeyo/package.json
@@ -8,7 +8,7 @@
         "build": "vite build",
         "watch": "BUILD_MODE=watch vite build --watch",
         "preview": "vite preview",
-        "deploy": "gh-pages -d dist"
+        "deploy": "npm run dev && gh-pages -d dist -e \"takeyo-projects\""
     },
     "dependencies": {
         "vue": "^3.4.15",


### PR DESCRIPTION
vite.config.jsでbaseを設定する必要はありません